### PR TITLE
Enforce path only in Alllow/Disallow

### DIFF
--- a/src/protego.py
+++ b/src/protego.py
@@ -4,7 +4,7 @@ from collections import namedtuple
 from datetime import time
 
 import six
-from six.moves.urllib.parse import (ParseResult, quote, unquote, urlparse,
+from six.moves.urllib.parse import (ParseResult, quote, urlparse,
                                     urlunparse)
 
 logger = logging.getLogger(__name__)

--- a/src/protego.py
+++ b/src/protego.py
@@ -38,6 +38,13 @@ def _is_valid_directive_field(field):
                 field in _HOST_DIRECTIVE])
 
 
+def _enforce_path(pattern):
+    if pattern.startswith('/'):
+        return pattern
+
+    return '/' + pattern
+
+
 class _URLPattern(object):
     """Internal class which represents a URL pattern."""
 
@@ -386,11 +393,11 @@ class Protego(object):
 
             elif field in _ALLOW_DIRECTIVE:
                 for rule_set in current_rule_sets:
-                    rule_set.allow(value)
+                    rule_set.allow(_enforce_path(value))
 
             elif field in _DISALLOW_DIRECTIVE:
                 for rule_set in current_rule_sets:
-                    rule_set.disallow(value)
+                    rule_set.disallow(_enforce_path(value))
 
             elif field in _SITEMAP_DIRECTIVE:
                 self._sitemap_list.append(value)

--- a/tests/test_protego.py
+++ b/tests/test_protego.py
@@ -333,33 +333,33 @@ class TestProtego(TestCase):
 
         content = """
         # robots.txt for http://www.example.com/
-        
+
         User-agent: Rule1TestBot
         Disallow:  /foo*
-        
+
         User-agent: Rule2TestBot
         Disallow:  /foo*/bar.html
-        
+
         # Disallows anything containing the letter m!
         User-agent: Rule3TestBot
         Disallow:  *m
-        
+
         User-agent: Rule4TestBot
         Allow:  /foo/bar.html
         Disallow: *
-        
+
         User-agent: Rule5TestBot
         Disallow:  /foo*/*bar.html
-        
+
         User-agent: Rule6TestBot
         Allow:  /foo$
         Disallow:  /foo
-        
+
         # Exercise excessive wildcards
         # https://bitbucket.org/philip_semanchuk/robotexclusionrulesparser/issues/1
         User-agent: Rule7TestBot
         Allow: *****************/****.js
-        
+
         """
         rp = Protego.parse(content=content)
 
@@ -450,13 +450,13 @@ class TestProtego(TestCase):
 
         content = u"""
         # robots.txt for http://www.example.com/
-        
+
         User-Agent: Jävla-Foobot
         Disallow: /
-        
+
         User-Agent: \u041b\u044c\u0432\u0456\u0432-bot
         Disallow: /totalitarianism/
-        
+
         """
         rp = Protego.parse(content=content)
 
@@ -792,10 +792,10 @@ class TestProtego(TestCase):
     def test_implicit_allow(self):
         content = """
         # robots.txt for http://www.example.com/
-        
+
         User-agent: *
         Disallow:    /
-        
+
         User-agent: foobot
         Disallow:
         """
@@ -840,7 +840,7 @@ class TestProtego(TestCase):
         robotstxt_incorrect_accepted = """
         user-agent foobot
         disallow /
-        user agent harry potter 
+        user agent harry potter
         disallow /horcrux
         request rate 1/10s 1820-1940
         """
@@ -1021,3 +1021,11 @@ class TestProtego(TestCase):
         self.assertFalse(rp.can_fetch("http://foo.bar/x*x/abc", "FooBot"))
         self.assertFalse(rp.can_fetch("http://foo.bar/x/abc$", "FooBot"))
         self.assertFalse(rp.can_fetch("http://foo.bar/x/abc%24", "FooBot"))
+
+    def test_with_absolute_urls(self):
+        content = ("user-agent: *\n"
+                   "disallow: http://ms-web00.walkerplus.com/\n")
+
+        rp = Protego.parse(content=content)
+        self.assertTrue(rp.can_fetch("http://foo.bar/", "FooBot"))
+        self.assertFalse(rp.can_fetch("http://foo.bar/http://ms-web00.walkerplus.com/", "FooBot"))

--- a/tox.ini
+++ b/tox.ini
@@ -28,11 +28,11 @@ deps = {[testenv:py35]deps}
 basepython = pypy
 commands =
     pypy setup.py install
-    pypy -m pytest {posargs}
+    pypy -m pytest {posargs:tests}
 
 [testenv:pypy3]
 basepython = pypy3
 deps = {[testenv:py35]deps}
 commands =
     pypy setup.py install
-    pypy -m pytest {posargs}
+    pypy -m pytest {posargs:tests}

--- a/tox.ini
+++ b/tox.ini
@@ -2,11 +2,11 @@
 envlist = py27,py37
 
 [testenv]
-deps = 
+deps =
     pytest
 commands =
     python setup.py install
-    pytest tests
+    pytest {posargs}
 
 [testenv:py35]
 basepython = python3.5
@@ -14,7 +14,7 @@ deps =
     pytest
 commands =
     python setup.py install
-    pytest tests
+    pytest {posargs}
 
 [testenv:py36]
 basepython = python3.6
@@ -28,11 +28,11 @@ deps = {[testenv:py35]deps}
 basepython = pypy
 commands =
     pypy setup.py install
-    pypy -m pytest tests
+    pypy -m pytest {posargs}
 
 [testenv:pypy3]
 basepython = pypy3
 deps = {[testenv:py35]deps}
 commands =
     pypy setup.py install
-    pypy -m pytest tests
+    pypy -m pytest {posargs}


### PR DESCRIPTION
After discussion @Gallaecio and I decided not to implement full URLs handling. To fix https://github.com/scrapy/protego/issues/4 and https://github.com/scrapy/scrapy/issues/4145 we enforce `/` at the start of Disallow/Allow patterns.

Also added ability to pass arguments from tox to pytest.