### PR TITLE
Prepare for wheel distributions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,12 +37,13 @@ install:
     virtualenv --python="$PYPY_VERSION/bin/pypy3" "$HOME/virtualenvs/$PYPY_VERSION"
     source "$HOME/virtualenvs/$PYPY_VERSION/bin/activate"
   fi
-- pip install -U codecov tox
+- pip install -U codecov tox wheel
 script: tox
 after_success:
   - codecov
 deploy:
   provider: pypi
+  distributions: "sdist bdist_wheel"
   user: anubhavp
   password:
     secure: bLB4MZIg6EdY3BysDbjNysufrvV6YpUZt6hOCWJ23HEiqsAIatvMAG1u8rkSoPLiYWuWsgeO+E18eu88LKc0GUvnUJjE5PB5ggt03dv7zSRcfhIo5othmxb65cRbAknL3vwaN8xzz6o6yAfrg1fapVwcWFnMxJgolmoB0nC0BQcpiUxrE8L9m56r+luWT6LhhSiSZdthCzJwi7OUV5NSDgYzxz2whgYXkrD3XxdDQgohYqwAzlThwGca/DOncntXOudlinf+g6fcBvNJf2lCwFls5sNg90H8XWub7J/xmG8bfXRTN5efIbP4KGaZR41wJHAl+CjgPVGsyy+vshDAwpmQLiBmoR04c6TYLpMg8idit3GMiWGGgtJGfeerl8WNeuyxGEXUrP5VJgM+9MVdknt1gMQgRVXk2TVKeFhakumqOMUsTTjrO8jEM/CwoRZpdhLupxagBaziXqM2VAEcSQYgiQ39xIZFSgobTG2IpCTU3kCUJobSmAOADBZMtfbFH/lmL+q5GAzf6h60GGmVVo424hv0HgDKEOuNLGnpXKeu8yVeE/QwgDkXSokBeKjiHqZBI7WD0rdY50B6aSvM2Zoo1UdygsitURnMvibKwg3rPc1tH082ZL+1ICgxp180yt6aXQj6yfl/CCA09qaAjy6eeNWR9fh50rFVvrkTNbU=

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[bdist_wheel]
+universal = 1
+
 [metadata]
 description-file = README.rst
 


### PR DESCRIPTION
Hey there,

While setting up a Scrapy-based project, I noticed the source tarball for Protego on PyPI is 3.2 megabytes, due to including all of the test case robots.txt files too. This is, based on the MANIFEST.in file, on purpose:
https://github.com/scrapy/protego/blob/26a5b11e1b9e949bbdc5ae8e5bdf68a939058df7/MANIFEST.in#L7
Some distros (e.g. Debian) do like their upstream source tarballs to include test material, so that's fine.

Those test files don't get included in wheel packages though, bringing the package size to a more reasonable 8 kilobytes. Pip will generally prefer wheels over source distributions so this is an easy way to bring the download size down for everyone.

```
~/b/protego (prepare-wheel) $ python setup.py sdist bdist_wheel
# ...
~/b/protego (prepare-wheel) $ ls -l dist
total 8256
-rw-r--r--  1 akx  staff     8220 Jan  2 15:53 Protego-0.1.16-py2.py3-none-any.whl
-rw-r--r--  1 akx  staff  3201309 Jan  2 15:56 Protego-0.1.16.tar.gz
```

This PR adds the required `universal = 1` configuration to `setup.cfg` so the wheel is marked compatible with both Python 2 and Python 3.

However, I'm not sure what the release process here entails; I see some deployment bits in the Travis configuration file, but I don't know what to add there to have the CI pipeline run `python setup.py bdist_wheel`.