### PR TITLE
Handle sitemaps that come before any user agent directives

### DIFF
--- a/src/protego.py
+++ b/src/protego.py
@@ -360,7 +360,7 @@ class Protego(object):
                 continue
 
             # Ignore rules without a corresponding user agent.
-            if not current_rule_sets and field not in _USER_AGENT_DIRECTIVE:
+            if not current_rule_sets and field not in _USER_AGENT_DIRECTIVE and field not in _SITEMAP_DIRECTIVE:
                 logger.debug("Rule at line {} without any user agent to enforce it on.".format(self._total_line_seen))
                 continue
 

--- a/tests/test_protego.py
+++ b/tests/test_protego.py
@@ -1045,3 +1045,11 @@ class TestProtego(TestCase):
         rp = Protego.parse(content=content)
         self.assertTrue(rp.can_fetch("http://foo.bar/", "FooBot"))
         self.assertFalse(rp.can_fetch("http://foo.bar/http://ms-web00.walkerplus.com/", "FooBot"))
+
+    def test_sitemaps_come_first(self):
+        """Some websites have sitemaps before any robots directives"""
+        content = ("Sitemap: https://www.foo.bar/sitmap.xml\n"
+                   "User-Agent: FootBot\n"
+                   "Disallow: /something")
+        rp = Protego.parse(content=content)
+        self.assertEquals(list(rp.sitemaps), ["https://www.foo.bar/sitmap.xml"])


### PR DESCRIPTION
Some robots.txt files have Sitemap directives that come before any User-Agent directives. This PR adds support for that.