### PR TITLE
Fix disallow not working when no path is provided

### DIFF
--- a/src/protego.py
+++ b/src/protego.py
@@ -170,7 +170,7 @@ class _RuleSet(object):
 
         parts = ParseResult('', '', path, parts.params, parts.query, parts.fragment)
         path = urlunparse(parts)
-        return path
+        return path or '/'
 
     def _quote_pattern(self, pattern):
         # Corner case for query only (e.g. '/abc?') and param only (e.g. '/abc;') URLs.

--- a/tests/test_protego.py
+++ b/tests/test_protego.py
@@ -1053,3 +1053,9 @@ class TestProtego(TestCase):
                    "Disallow: /something")
         rp = Protego.parse(content=content)
         self.assertEquals(list(rp.sitemaps), ["https://www.foo.bar/sitmap.xml"])
+
+    def test_disallow_target_url_path_is_missing(self):
+        content = "User-Agent: *\nDisallow: /\n"
+        rp = Protego.parse(content)
+        self.assertFalse(rp.can_fetch("http://example.com/", "FooBot"))
+        self.assertFalse(rp.can_fetch("http://example.com", "FooBot"))


### PR DESCRIPTION
This close #17

I try a simple approach, when we don't have any path we return the default `/`