### PR TITLE
Fix readme content type and Travis deploy step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,4 +64,4 @@ deploy:
   on:
     tags: true
     repo: scrapy/protego
-    condition: "$TOXENV == py27 && $TRAVIS_TAG =~ ^[0-9]+[.][0-9]+[.][0-9]+(rc[0-9]+|[.]dev[0-9]+)?$"
+    condition: "$TOXENV == py39 && $TRAVIS_TAG =~ ^[0-9]+[.][0-9]+[.][0-9]+(rc[0-9]+|[.]dev[0-9]+)?$"

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,10 @@
 from setuptools import setup, find_packages
 
 setup(name='Protego',
-      version='0.2.0',
+      version='0.2.1',
       description='Pure-Python robots.txt parser with support for modern conventions',
       long_description=open("README.rst").read(),
-      long_description_content_type='text/markdown',
+      long_description_content_type='text/x-rst',
       url='https://github.com/scrapy/protego',
       author='Anubhav Patel',
       author_email='anubhavp28@gmail.com',


### PR DESCRIPTION
`long_description_content_type` was incorrectly set to `text/markdown` in `setup.py`. Also, `pip` has dropped support for Python 2.7 causing the Travis deploy step to fail.