### PR TITLE
fix: Code coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,4 @@
 [run]
 branch = true
-include = src/protego.py
+include = src/*
 omit = tests/*

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,6 +4,3 @@ comment:
 coverage:
   status:
     project: false
-
-fixes:
-  - "::src/"

--- a/tox.ini
+++ b/tox.ini
@@ -6,11 +6,11 @@ deps =
     pytest
     pytest-cov
 commands =
-    python setup.py install
+    pip install -e .
     pytest --cov=protego --cov-report=xml --cov-report= {posargs:tests}
 
 [testenv:pypy3]
 basepython = pypy3
 commands =
-    pypy setup.py install
+    pip install -e .
     pypy -m pytest {posargs:tests}


### PR DESCRIPTION
This make our code coverage work. 🎉 

By installing package via `pip install -e .` command instead of `python setup.py install`