### PR TITLE
Add equal-sign to parse safe characters

### DIFF
--- a/src/protego.py
+++ b/src/protego.py
@@ -184,7 +184,7 @@ class _RuleSet(object):
 
         parts = urlparse(pattern)
         pattern = self._unquote(parts.path, ignore="/*$%")
-        pattern = quote(pattern, safe="/*%")
+        pattern = quote(pattern, safe="/*%=")
 
         parts = ParseResult(
             "", "", pattern + last_char, parts.params, parts.query, parts.fragment

--- a/tests/test_protego.py
+++ b/tests/test_protego.py
@@ -1141,6 +1141,16 @@ class TestProtego(TestCase):
         self.assertEqual(start_time, time(5, 0))
         self.assertEqual(end_time, time(6, 0))
 
+    def test_disallow_query_wildcard(self):
+        content = (
+            "User-agent: * \n"
+            "Disallow: /*s="
+        )
+        rp = Protego.parse(content=content)
+        self.assertTrue(rp.can_fetch("https://www.site.local/", "*"))
+        self.assertTrue(rp.can_fetch("https://www.site.local/s/", "*"))
+        self.assertFalse(rp.can_fetch("https://www.site.local/?s=asd", "*"))
+
 
 @pytest.mark.parametrize(
     "allow,disallow,url,allowed",

--- a/tests/test_protego.py
+++ b/tests/test_protego.py
@@ -1142,10 +1142,7 @@ class TestProtego(TestCase):
         self.assertEqual(end_time, time(6, 0))
 
     def test_disallow_query_wildcard(self):
-        content = (
-            "User-agent: * \n"
-            "Disallow: /*s="
-        )
+        content = "User-agent: * \nDisallow: /*s="
         rp = Protego.parse(content=content)
         self.assertTrue(rp.can_fetch("https://www.site.local/", "*"))
         self.assertTrue(rp.can_fetch("https://www.site.local/s/", "*"))


### PR DESCRIPTION
This PR fixes the issue mentioned in https://github.com/scrapy/protego/issues/29