### PR TITLE
Verified PyPI releases (a.k.a. PEP740)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,14 +7,18 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/protego
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: 3.13
-      - run: pip install --upgrade setuptools wheel
-      - run: python setup.py sdist bdist_wheel
+      - run: |
+          python -m pip install --upgrade build
+          python -m build
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Same drill as in https://github.com/scrapy/scrapy/pull/6543

Will need someone with PyPI's project access to add a trusted publisher at https://pypi.org/manage/project/protego/settings/publishing/