### PR TITLE
Add type hints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.11.2
+  rev: v0.11.12
   hooks:
-    - id: ruff
+    - id: ruff-check
       args: [ --fix ]
     - id: ruff-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,10 @@ exclude_also = [
     "if TYPE_CHECKING:",
 ]
 
+[[tool.mypy.overrides]]
+module = "tests.*"
+allow_untyped_defs = true
+
 [tool.ruff.lint]
 extend-select = [
     # flake8-bugbear
@@ -129,10 +133,6 @@ ignore = [
     "RUF012",
     # Use of `assert` detected
     "S101",
-
-    # to be done when adding type hints
-    # Use `typing.NamedTuple` instead of `collections.namedtuple`
-    "PYI024",
 ]
 
 [tool.ruff.lint.pydocstyle]

--- a/src/protego.py
+++ b/src/protego.py
@@ -157,25 +157,24 @@ class _RuleSet:
         # meant to be converted back.
         ignore_set = {f"{ord(c):02X}" for c in ignore}
 
-        # TODO: try to refactor this
         parts = url.split("%")
         parts_encoded: list[bytes] = [parts[0].encode("utf-8")]
 
-        for i in range(1, len(parts)):
+        for part in parts[1:]:
             # %xy is a valid escape only if x and y are hexadecimal digits.
-            if len(parts[i]) >= 2 and set(parts[i][:2]).issubset(_HEX_DIGITS):
+            if len(part) >= 2 and set(part[:2]).issubset(_HEX_DIGITS):
                 # make sure that all %xy escapes are in uppercase.
-                hexcode = parts[i][:2].upper()
-                leftover = parts[i][2:]
+                hexcode = part[:2].upper()
+                leftover = part[2:]
                 if hexcode not in ignore_set:
                     parts_encoded.append(
                         hex_to_byte(hexcode) + leftover.encode("utf-8")
                     )
                     continue
-                parts[i] = hexcode + leftover
+                part = hexcode + leftover
 
             # add back the '%' we removed during splitting.
-            parts_encoded.append(b"%" + parts[i].encode("utf-8"))
+            parts_encoded.append(b"%" + part.encode("utf-8"))
 
         return b"".join(parts_encoded).decode("utf-8", errors)
 

--- a/tests/test_on_fetched_robotstxt.py
+++ b/tests/test_on_fetched_robotstxt.py
@@ -9,7 +9,7 @@ robotstxts = [f for f in test_data_directory.iterdir() if f.is_file()]
 
 
 @pytest.mark.parametrize("path_to_robotstxt", robotstxts)
-def test_no_exceptions(path_to_robotstxt):
+def test_no_exceptions(path_to_robotstxt: Path) -> None:
     try:
         try:
             content = path_to_robotstxt.read_bytes().decode("utf-8")

--- a/tests/test_on_google_spec.py
+++ b/tests/test_on_google_spec.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from protego import Protego
@@ -27,6 +29,7 @@ def test_user_agent_precedence(path, user_agent):
     allow: /group3
     """
     rp = Protego.parse(content=robotstxt_content)
+    allowed_path: str | None
     for allowed_path in ("/group1", "/group2", "/group3"):
         if rp.can_fetch(allowed_path, user_agent):
             break

--- a/tests/test_protego.py
+++ b/tests/test_protego.py
@@ -225,30 +225,37 @@ class TestProtego(TestCase):
         rp = Protego.parse(content=content)
 
         req_rate = rp.request_rate("one")
+        assert req_rate is not None
         self.assertTrue(req_rate.requests == 1)
         self.assertTrue(req_rate.seconds == 10)
         self.assertTrue(req_rate.start_time is None)
         self.assertTrue(req_rate.end_time is None)
 
         req_rate = rp.request_rate("two")
+        assert req_rate is not None
         self.assertTrue(req_rate.requests == 100)
         self.assertTrue(req_rate.seconds == 900)
         self.assertTrue(req_rate.start_time is None)
         self.assertTrue(req_rate.end_time is None)
 
         req_rate = rp.request_rate("three")
+        assert req_rate is not None
         self.assertTrue(req_rate.requests == 400)
         self.assertTrue(req_rate.seconds == 3600)
         self.assertTrue(req_rate.start_time is None)
         self.assertTrue(req_rate.end_time is None)
 
         req_rate = rp.request_rate("four")
+        assert req_rate is not None
         self.assertTrue(req_rate.requests == 9000)
         self.assertTrue(req_rate.seconds == 86400)
         self.assertTrue(req_rate.start_time is None)
         self.assertTrue(req_rate.end_time is None)
 
         req_rate = rp.request_rate("five")
+        assert req_rate is not None
+        assert req_rate.start_time is not None
+        assert req_rate.end_time is not None
         self.assertTrue(req_rate.requests == 1)
         self.assertTrue(req_rate.seconds == 10)
         self.assertTrue(req_rate.start_time.hour == 18)
@@ -884,6 +891,9 @@ class TestProtego(TestCase):
         self.assertFalse(rp.can_fetch("http://foo.bar/horcrux", "harry potter"))
         self.assertTrue(rp.can_fetch("http://foo.bar/abc", "harry potter"))
         req_rate = rp.request_rate("harry potter")
+        assert req_rate is not None
+        assert req_rate.start_time is not None
+        assert req_rate.end_time is not None
         self.assertTrue(req_rate.requests == 1)
         self.assertTrue(req_rate.seconds == 10)
         self.assertTrue(req_rate.start_time.hour == 18)
@@ -1078,7 +1088,7 @@ class TestProtego(TestCase):
     def test_bytestrings(self):
         content = b"User-Agent: FootBot\nDisallow: /something"
         with self.assertRaises(ValueError) as context:
-            Protego.parse(content=content)
+            Protego.parse(content=content)  # type: ignore[arg-type]
 
         self.assertEqual("Protego.parse expects str, got bytes", str(context.exception))
 
@@ -1097,17 +1107,17 @@ class TestProtego(TestCase):
         content = "User-Agent: *\nVisit-time: 0200 0630\nUser-Agent: NoTime"
         rp = Protego.parse(content)
         visit_time = rp.visit_time("FooBoot")
+        assert visit_time is not None
         self.assertEqual(visit_time.start_time, time(2, 0))
         self.assertEqual(visit_time.end_time, time(6, 30))
         self.assertIsNone(rp.visit_time("NoTime"))
 
     def test_parse_time_period(self):
-        rs = _RuleSet(None)
-        start_time, end_time = rs._parse_time_period("0100-1000")
+        start_time, end_time = _RuleSet._parse_time_period("0100-1000")
         self.assertEqual(start_time, time(1, 0))
         self.assertEqual(end_time, time(10, 0))
 
-        start_time, end_time = rs._parse_time_period("0500 0600", separator=" ")
+        start_time, end_time = _RuleSet._parse_time_period("0500 0600", separator=" ")
         self.assertEqual(start_time, time(5, 0))
         self.assertEqual(end_time, time(6, 0))
 

--- a/tests/test_unquote.py
+++ b/tests/test_unquote.py
@@ -2,16 +2,6 @@ from unittest import TestCase
 
 from protego import _RuleSet
 
-rs = _RuleSet(None)
-
-
-def _unquote(url, ignore="", errors="replace"):
-    return rs._unquote(url, ignore, errors)
-
-
-def hexescape(char):
-    return rs.hexescape(char)
-
 
 class TestUnquote(TestCase):
     """Tests for unquote()"""
@@ -20,16 +10,16 @@ class TestUnquote(TestCase):
         # Make sure unquoting of all ASCII values works
         escape_list = []
         for num in range(128):
-            given = hexescape(chr(num))
+            given = _RuleSet.hexescape(chr(num))
             expect = chr(num)
-            result = _unquote(given)
+            result = _RuleSet._unquote(given)
             self.assertEqual(
                 expect, result, f"using unquote(): {expect!r} != {result!r}"
             )
             escape_list.append(given)
         escape_string = "".join(escape_list)
         del escape_list
-        result = _unquote(escape_string)
+        result = _RuleSet._unquote(escape_string)
         self.assertEqual(
             result.count("%"),
             1,
@@ -40,73 +30,73 @@ class TestUnquote(TestCase):
         # Test unquoting on bad percent-escapes
         given = "%xab"
         expect = given
-        result = _unquote(given)
+        result = _RuleSet._unquote(given)
         self.assertEqual(expect, result, f"using unquote(): {expect!r} != {result!r}")
 
         given = "%x"
         expect = given
-        result = _unquote(given)
+        result = _RuleSet._unquote(given)
         self.assertEqual(expect, result, f"using unquote(): {expect!r} != {result!r}")
 
         given = "%"
         expect = given
-        result = _unquote(given)
+        result = _RuleSet._unquote(given)
         self.assertEqual(expect, result, f"using unquote(): {expect!r} != {result!r}")
 
     def test_unquoting_parts(self):
         # Make sure unquoting works when have non-quoted characters
         # interspersed
-        given = f"ab{hexescape('c')}d"
+        given = f"ab{_RuleSet.hexescape('c')}d"
         expect = "abcd"
-        result = _unquote(given)
+        result = _RuleSet._unquote(given)
         self.assertEqual(expect, result, f"using quote(): {expect!r} != {result!r}")
 
     def test_unquoting_plus(self):
         # Test difference between unquote() and unquote_plus()
         given = "are+there+spaces..."
         expect = given
-        result = _unquote(given)
+        result = _RuleSet._unquote(given)
         self.assertEqual(expect, result, f"using unquote(): {expect!r} != {result!r}")
 
     def test_unquote_with_unicode(self):
         # Characters in the Latin-1 range, encoded with UTF-8
         given = "br%C3%BCckner_sapporo_20050930.doc"
         expect = "br\u00fcckner_sapporo_20050930.doc"
-        result = _unquote(given)
+        result = _RuleSet._unquote(given)
         self.assertEqual(expect, result, f"using unquote(): {expect!r} != {result!r}")
 
         # Characters in the Latin-1 range, encoded with None (default)
-        result = _unquote(given)
+        result = _RuleSet._unquote(given)
         self.assertEqual(expect, result, f"using unquote(): {expect!r} != {result!r}")
 
         # Characters in BMP, encoded with UTF-8
         given = "%E6%BC%A2%E5%AD%97"
         expect = "\u6f22\u5b57"  # "Kanji"
-        result = _unquote(given)
+        result = _RuleSet._unquote(given)
         self.assertEqual(expect, result, f"using unquote(): {expect!r} != {result!r}")
 
         # Decode with UTF-8, invalid sequence
         given = "%F3%B1"
         expect = "\ufffd"  # Replacement character
-        result = _unquote(given)
+        result = _RuleSet._unquote(given)
         self.assertEqual(expect, result, f"using unquote(): {expect!r} != {result!r}")
 
         # Decode with UTF-8, invalid sequence, replace errors
-        result = _unquote(given, errors="replace")
+        result = _RuleSet._unquote(given, errors="replace")
         self.assertEqual(expect, result, f"using unquote(): {expect!r} != {result!r}")
 
         # Decode with UTF-8, invalid sequence, ignoring errors
         given = "%F3%B1"
         expect = ""
-        result = _unquote(given, errors="ignore")
+        result = _RuleSet._unquote(given, errors="ignore")
         self.assertEqual(expect, result, f"using unquote(): {expect!r} != {result!r}")
 
         # A mix of non-ASCII and percent-encoded characters, UTF-8
-        result = _unquote("\u6f22%C3%BC")
+        result = _RuleSet._unquote("\u6f22%C3%BC")
         expect = "\u6f22\u00fc"
         self.assertEqual(expect, result, f"using unquote(): {expect!r} != {result!r}")
 
     def test_escape_sequence_uppercase(self):
-        result = _unquote("%2fabc%7exyz", ignore="/~")
+        result = _RuleSet._unquote("%2fabc%7exyz", ignore="/~")
         expect = "%2Fabc%7Exyz"
         self.assertEqual(expect, result, f"using unquote(): {expect!r} != {result!r}")

--- a/tox.ini
+++ b/tox.ini
@@ -26,3 +26,12 @@ deps =
 commands =
     python -m build --sdist
     twine check dist/*
+
+[testenv:typing]
+basepython = python3
+deps =
+    mypy==1.16.0
+    pytest
+    scrapy==2.13.1
+commands =
+    mypy --strict {posargs: src tests}


### PR DESCRIPTION
Not adding py.typed, because currently protego is a single-file module and py.typed needs a package (so I think we will need to change `protego.py` to `protego/__init__.py`). https://typing.python.org/en/latest/spec/distributing.html#packaging-type-information