### PR TITLE
Fix user agent rule matching

### DIFF
--- a/src/protego/_ruleset.py
+++ b/src/protego/_ruleset.py
@@ -49,8 +49,11 @@ class _RuleSet:
         robotname = robotname.strip().lower()
         if self.user_agent == "*":
             return 1
-        if self.user_agent in robotname:
-            return len(self.user_agent)
+        start = robotname.find(self.user_agent)
+        while start != -1:
+            if start == 0 or not robotname[start - 1].isalnum():
+                return len(self.user_agent)
+            start = robotname.find(self.user_agent, start + 1)
         return 0
 
     def allow(self, pattern: str) -> None:

--- a/tests/test_protego.py
+++ b/tests/test_protego.py
@@ -489,6 +489,24 @@ class TestProtego:
         assert not rp.can_fetch("https://site.local/testbot", "tEStbOt")
         assert rp.can_fetch("https://site.local/default-UA", "tEStbOt")
 
+    def test_user_agent_prefix_matching(self):
+        content = """
+        User-Agent: bot
+        Disallow: /bot
+
+        User-Agent: google
+        Disallow: /google
+
+        User-Agent: googlebot
+        Allow: /google
+        Disallow: /googlebot
+        """
+        rp = Protego.parse(content=content)
+        assert rp.can_fetch("https://site.local/bot", "mybot")
+        assert not rp.can_fetch("https://site.local/bot", "bot")
+        assert rp.can_fetch("https://site.local/google", "googlebot-mobile")
+        assert not rp.can_fetch("https://site.local/googlebot", "googlebot-mobile")
+
     def test_user_agent_grouping(self):
         content = """
         User-Agent: one


### PR DESCRIPTION
Fixes #65.

This avoids matching user-agent directives in the middle of a product token, so `bot` no longer matches `mybot`. It still allows matches at token boundaries, which keeps existing `Mozilla/5.0 (compatible; SomeBot/...)` style user agents working.

Added coverage for the partial-match case and for choosing the more specific `googlebot` rule over `google`.