### PR TITLE
Match user agents at token boundaries (fixes #65)

### DIFF
--- a/src/protego/_ruleset.py
+++ b/src/protego/_ruleset.py
@@ -49,8 +49,17 @@ class _RuleSet:
         robotname = robotname.strip().lower()
         if self.user_agent == "*":
             return 1
-        if self.user_agent in robotname:
-            return len(self.user_agent)
+        # Match the product token only at a token boundary. This avoids
+        # false positives such as "bot" matching "mybot", while still
+        # matching a token within a full User-Agent header, e.g.
+        # "Mozilla/5.0 (compatible; Foobot/1.0)" matching "foobot".
+        index = robotname.find(self.user_agent)
+        while index != -1:
+            if index == 0 or not (
+                robotname[index - 1].isalnum() or robotname[index - 1] in "-_"
+            ):
+                return len(self.user_agent)
+            index = robotname.find(self.user_agent, index + 1)
         return 0
 
     def allow(self, pattern: str) -> None:

--- a/tests/test_on_google_spec.py
+++ b/tests/test_on_google_spec.py
@@ -39,6 +39,32 @@ def test_user_agent_precedence(path, user_agent):
 
 
 @pytest.mark.parametrize(
+    ("robots_user_agent", "crawler_user_agent", "applies"),
+    [
+        # A product token must not match as a substring in the middle of
+        # another token (https://github.com/scrapy/protego/issues/65).
+        ("bot", "mybot", False),
+        ("google", "notgooglebot", False),
+        # Exact matches and boundary prefixes do apply.
+        ("googlebot", "googlebot", True),
+        ("googlebot", "googlebot-news", True),
+        ("google", "googlebot-mobile", True),
+        # A token embedded in a full User-Agent header still applies.
+        ("foobot", "Mozilla/5.0 (compatible; Foobot/1.0)", True),
+        # Matching is case-insensitive.
+        ("foobot", "FOOBOT", True),
+    ],
+)
+def test_user_agent_boundary_matching(robots_user_agent, crawler_user_agent, applies):
+    content = f"User-Agent: {robots_user_agent}\nDisallow: /private\n"
+    rp = Protego.parse(content=content)
+    # When the group applies, /private is disallowed for the crawler.
+    assert (
+        not rp.can_fetch("http://example.com/private", crawler_user_agent)
+    ) == applies
+
+
+@pytest.mark.parametrize(
     ("pattern", "path", "match"),
     [
         ("/", "/harry", True),


### PR DESCRIPTION
Fixes #65.

## Problem
`_RuleSet.applies_to()` matched the robots.txt user-agent against the crawler name with a plain substring check (`self.user_agent in robotname`). This caused false positives: a `User-agent: bot` group wrongly applied to a crawler named `mybot`, and `google` matched `notgooglebot`.

## Fix
Match the product token only at a **token boundary**: the user-agent must appear at the start of the crawler name, or immediately after a non-token character. This:

- rejects mid-token substring matches (`bot` no longer matches `mybot`);
- still matches a token inside a full `User-Agent` header, e.g. `Mozilla/5.0 (compatible; Foobot/1.0)` matches `foobot`, preserving the existing Львів-bot expectation in `tests/test_protego.py`. A naive `robotname.startswith(...)` would have regressed that case.

Case-insensitivity and the `*` catch-all are unchanged. The no-match fallback already exists in `_get_matching_rule_set()` (returns `None`, i.e. default allow), so nothing was needed there.

## Tests
Added `test_user_agent_boundary_matching` covering substring rejection, exact/prefix matches, full-User-Agent-header matches, and case-insensitivity. The full suite passes locally on Python 3.14 (4353 tests), and `ruff check` / `ruff format` are clean.