### PR TITLE
Keep '=' literal in URL paths so they match patterns (fixes #51)

### DIFF
--- a/src/protego/_utils.py
+++ b/src/protego/_utils.py
@@ -52,7 +52,9 @@ def _quote_path(path: str) -> str:
     """Return percent encoded path."""
     parts = urlparse(path)
     path = _unquote(parts.path, ignore="/%")
-    path = quote(path, safe="/%")
+    # Keep "=" unescaped so paths match patterns, which also keep "=" literal
+    # (see _quote_pattern). https://github.com/scrapy/protego/issues/51
+    path = quote(path, safe="/%=")
 
     parts = ParseResult("", "", path, parts.params, parts.query, parts.fragment)
     path = urlunparse(parts)

--- a/tests/test_on_google_spec.py
+++ b/tests/test_on_google_spec.py
@@ -133,14 +133,21 @@ def test_record_precedence(rules, url, allowed):
             "http://example.com/a/filter/page=99/",
             True,
         ),
+        # A pre-encoded "%3D" in the URL is normalised back to "=" and matches.
+        (
+            "User-agent: *\nAllow: /*/filter/page=*/$\nDisallow: /\n",
+            "http://example.com/1/filter/page%3D5/",
+            True,
+        ),
         # The trailing "$" still requires the path to end right after the slash.
         (
             "User-agent: *\nAllow: /*/filter/page=*/$\nDisallow: /\n",
             "http://example.com/1/filter/page=5",
             False,
         ),
-        # "=" must be matched literally without wildcards too.
+        # Non-wildcard patterns are prefix matches, and "=" is literal there too.
         ("User-agent: *\nDisallow: /path=1\n", "http://example.com/path=1", False),
+        ("User-agent: *\nDisallow: /path=1\n", "http://example.com/path=12", False),
         ("User-agent: *\nDisallow: /path=1\n", "http://example.com/path=2", True),
     ],
 )

--- a/tests/test_on_google_spec.py
+++ b/tests/test_on_google_spec.py
@@ -117,3 +117,34 @@ def test_record_precedence(rules, url, allowed):
     """
     rp = Protego.parse(content)
     assert rp.can_fetch(url, "*") == allowed
+
+
+@pytest.mark.parametrize(
+    ("content", "url", "allowed"),
+    [
+        # "=" in a wildcard pattern must match "=" in the URL path.
+        (
+            "User-agent: *\nAllow: /*/filter/page=*/$\nDisallow: /\n",
+            "http://example.com/1/filter/page=5/",
+            True,
+        ),
+        (
+            "User-agent: *\nAllow: /*/filter/page=*/$\nDisallow: /\n",
+            "http://example.com/a/filter/page=99/",
+            True,
+        ),
+        # The trailing "$" still requires the path to end right after the slash.
+        (
+            "User-agent: *\nAllow: /*/filter/page=*/$\nDisallow: /\n",
+            "http://example.com/1/filter/page=5",
+            False,
+        ),
+        # "=" must be matched literally without wildcards too.
+        ("User-agent: *\nDisallow: /path=1\n", "http://example.com/path=1", False),
+        ("User-agent: *\nDisallow: /path=1\n", "http://example.com/path=2", True),
+    ],
+)
+def test_equals_sign_in_path(content, url, allowed):
+    # Regression test for https://github.com/scrapy/protego/issues/51
+    rp = Protego.parse(content)
+    assert rp.can_fetch(url, "mozilla") == allowed


### PR DESCRIPTION
Fixes #51.

## Problem
`_quote_path()` (used to normalize the URL being checked) percent-encodes `=`, because its `quote()` call uses `safe="/%"`. But `_quote_pattern()` (used to normalize `Allow`/`Disallow` patterns) keeps `=` literal via `safe="/*%="`.

Because of this asymmetry, a pattern containing `=` can never match a URL whose path contains `=`: the pattern keeps `page=`, while the URL becomes `page%3D`.

Example from the issue:

    User-agent: *
    Allow:    /*/filter/page=*/$
    Disallow: /

`can_fetch("https://example.com/1/filter/page=5/", "mozilla")` returned `False` (the URL had been normalized to `/1/filter/page%3D5/`, which the `.../page=.../` pattern could not match), when it should be `True`.

## Fix
Add `=` to the `safe` set in `_quote_path()` so URL paths keep `=` literal, matching how patterns are already normalized. `=` is a valid path character (an RFC 3986 sub-delimiter) and does not need percent-encoding.

## Tests
Added `test_equals_sign_in_path`, covering the wildcard case from the issue, the trailing-`$` boundary, and a plain (non-wildcard) `=` path. Full suite passes locally on Python 3.14 (4351 tests); `ruff check` / `ruff format` are clean.