### PR TITLE
Support hyphenated Visit-time, fix parsing times and rates.

### DIFF
--- a/src/protego/_ruleset.py
+++ b/src/protego/_ruleset.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import math
 from typing import TYPE_CHECKING, NamedTuple
 
 from ._urlpattern import _URLPattern
@@ -99,13 +100,17 @@ class _RuleSet:
     @crawl_delay.setter
     def crawl_delay(self, delay: str) -> None:
         try:
-            self._crawl_delay = float(delay)
+            parsed_delay = float(delay)
         except ValueError:
+            parsed_delay = None
+        if parsed_delay is None or not math.isfinite(parsed_delay) or parsed_delay < 0:
             # Value is malformed, do nothing.
             logger.debug(
                 f"Malformed rule at line {self._parser_instance._total_line_seen} : "
                 f"cannot set crawl delay to '{delay}'. Ignoring this rule."
             )
+            return
+        self._crawl_delay = parsed_delay
 
     @property
     def request_rate(self) -> RequestRate | None:
@@ -129,6 +134,9 @@ class _RuleSet:
                 time_unit = "s"
                 seconds = int(seconds_str)
             requests = int(requests_str)
+
+            if requests <= 0 or seconds <= 0:
+                raise ValueError(f"Request rate must be positive: {value!r}")
 
             if time_unit == "m":
                 seconds *= 60
@@ -159,7 +167,12 @@ class _RuleSet:
     @visit_time.setter
     def visit_time(self, value: str) -> None:
         try:
-            start_time, end_time = _parse_time_period(value, separator=" ")
+            try:
+                # "0400-0845"
+                start_time, end_time = _parse_time_period(value)
+            except ValueError:
+                # "0400 0845"
+                start_time, end_time = _parse_time_period(value, separator=" ")
         except Exception:
             logger.debug(
                 f"Malformed rule at line {self._parser_instance._total_line_seen} : "

--- a/src/protego/_utils.py
+++ b/src/protego/_utils.py
@@ -6,12 +6,18 @@ from urllib.parse import ParseResult, quote, urlparse, urlunparse
 _HEX_DIGITS = set("0123456789ABCDEFabcdef")
 
 
+def _parse_time_of_day(value: str) -> time:
+    """Parse an HMM or HHMM time-of-day value."""
+    value = value.strip()
+    if not (3 <= len(value) <= 4 and value.isascii() and value.isdigit()):
+        raise ValueError(f"Invalid time of day: {value!r}")
+    return time(int(value[:-2]), int(value[-2:]))
+
+
 def _parse_time_period(time_period: str, separator: str = "-") -> tuple[time, time]:
     """Parse a string with a time period into a tuple of start and end times."""
     start_time_str, end_time_str = time_period.split(separator)
-    start_time = time(int(start_time_str[:2]), int(start_time_str[-2:]))
-    end_time = time(int(end_time_str[:2]), int(end_time_str[-2:]))
-    return start_time, end_time
+    return _parse_time_of_day(start_time_str), _parse_time_of_day(end_time_str)
 
 
 def _unquote(url: str, ignore: str = "", errors: str = "replace") -> str:

--- a/tests/test_protego.py
+++ b/tests/test_protego.py
@@ -179,28 +179,32 @@ class TestProtego:
         rp = Protego.parse(content=content)
         assert rp.preferred_host is None
 
-    def test_crawl_delay(self):
+    @pytest.mark.parametrize("value", [0, 10, 15])
+    def test_crawl_delay(self, value: int) -> None:
         content = (
             "User-agent: * \n"
             "Disallow: /disallowed \n"
             "Allow: /allowed \n"
             "Crawl-delay: 10 \n"
             "User-agent: testbot\n"
-            "Crawl-delay: 15 \n"
+            f"Crawl-delay: {value}\n"
         )
         rp = Protego.parse(content=content)
         assert rp.crawl_delay("*") == 10.0
-        assert rp.crawl_delay("testbot") == 15.0
+        assert rp.crawl_delay("testbot") == value
 
-    def test_malformed_crawl_delay(self):
+    @pytest.mark.parametrize(
+        "value", ["random_word", "-5", "-0.5", "inf", "-inf", "nan"]
+    )
+    def test_malformed_crawl_delay(self, value: str) -> None:
         content = (
             "User-agent: * \n"
             "Disallow: /disallowed \n"
             "Allow: /allowed \n"
-            "Crawl-delay: random_word"
+            f"Crawl-delay: {value}"
         )
         rp = Protego.parse(content=content)
-        assert rp.crawl_delay("*") is None
+        assert rp.crawl_delay("*") is None, value
 
     def test_no_crawl_delay(self):
         content = "User-agent: * \nDisallow: /disallowed \nAllow: /allowed"
@@ -316,6 +320,25 @@ class TestProtego:
         """
         rp = Protego.parse(content=content)
         assert rp.request_rate("two") is None
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "one/two",
+            "5",
+            "-1/5",
+            "0/5",
+            "1/0",
+            "0/0",
+            "1/-5",
+            # A malformed time window invalidates the whole rule.
+            "1/5 9-17",
+        ],
+    )
+    def test_malformed_request_rate(self, value):
+        content = f"User-agent: *\nRequest-rate: {value}"
+        rp = Protego.parse(content=content)
+        assert rp.request_rate("*") is None
 
     def test_empty_response(self):
         """empty response should equal 'allow all'"""
@@ -1072,14 +1095,39 @@ class TestProtego:
         assert not rp.can_fetch("http://example.com//folder/page", "FooBot")
 
     def test_visit_time(self):
-        """Some website specified allow time for crawling in UTC"""
-        content = "User-Agent: *\nVisit-time: 0200 0630\nUser-Agent: NoTime"
+        """The de-facto Visit-time convention, from the "Extended Standard
+        for Robot Exclusion", is hyphen-separated."""
+        content = "User-Agent: *\nVisit-time: 0400-0845\nUser-Agent: NoTime"
         rp = Protego.parse(content)
-        visit_time = rp.visit_time("FooBoot")
+        visit_time = rp.visit_time("FooBot")
+        assert visit_time is not None
+        assert visit_time.start_time == time(4, 0)
+        assert visit_time.end_time == time(8, 45)
+        assert rp.visit_time("NoTime") is None
+
+        # The space-separated form is also accepted.
+        content = "User-Agent: *\nVisit-time: 0200 0630"
+        rp = Protego.parse(content)
+        visit_time = rp.visit_time("FooBot")
         assert visit_time is not None
         assert visit_time.start_time == time(2, 0)
         assert visit_time.end_time == time(6, 30)
-        assert rp.visit_time("NoTime") is None
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "9-17",
+            "900",
+            "0400-",
+            "0400-0845-1000",
+            "2500-2600",
+            "abcd-efgh",
+        ],
+    )
+    def test_malformed_visit_time(self, value):
+        content = f"User-Agent: *\nVisit-time: {value}"
+        rp = Protego.parse(content)
+        assert rp.visit_time("FooBot") is None
 
     def test_parse_time_period(self):
         start_time, end_time = _parse_time_period("0100-1000")
@@ -1089,6 +1137,15 @@ class TestProtego:
         start_time, end_time = _parse_time_period("0500 0600", separator=" ")
         assert start_time == time(5, 0)
         assert end_time == time(6, 0)
+
+        # Three-digit values are read as HMM.
+        start_time, end_time = _parse_time_period("900-1700")
+        assert start_time == time(9, 0)
+        assert end_time == time(17, 0)
+
+        for time_period in ["9-17", "18-19", "-", "0900-", "090000-100000"]:
+            with pytest.raises(ValueError, match="Invalid time of day"):
+                _parse_time_period(time_period)
 
     def test_disallow_query_wildcard(self):
         content = "User-agent: * \nDisallow: /*s="


### PR DESCRIPTION
All `Visit-time` values in `tests/test_data` are hyphenated while we only supported space-separated ones. Also reject some invalid values in `Visit-time`, `Crawl-delay` and `Request-rate`.