### PR TITLE
Improve handling of invalid/misspelled lines.

### DIFF
--- a/src/protego/_protego.py
+++ b/src/protego/_protego.py
@@ -31,19 +31,71 @@ _REQUEST_RATE_DIRECTIVE = {"request-rate", "request rate"}
 _VISIT_TIME_DIRECTIVE = {"visit-time", "visit time"}
 _HOST_DIRECTIVE = {"host"}
 
+# Directives that apply to the whole site rather than to a record group.
+_SITE_WIDE_DIRECTIVES = _SITEMAP_DIRECTIVE | _HOST_DIRECTIVE
+
+_ALL_DIRECTIVES = (
+    _DISALLOW_DIRECTIVE
+    | _ALLOW_DIRECTIVE
+    | _USER_AGENT_DIRECTIVE
+    | _SITEMAP_DIRECTIVE
+    | _CRAWL_DELAY_DIRECTIVE
+    | _REQUEST_RATE_DIRECTIVE
+    | _VISIT_TIME_DIRECTIVE
+    | _HOST_DIRECTIVE
+)
+
+_MAX_DIRECTIVE_WORDS = max(len(alias.split()) for alias in _ALL_DIRECTIVES)
+
 
 def _is_valid_directive_field(field: str) -> bool:
-    return any(
-        [
-            field in _DISALLOW_DIRECTIVE,
-            field in _ALLOW_DIRECTIVE,
-            field in _USER_AGENT_DIRECTIVE,
-            field in _SITEMAP_DIRECTIVE,
-            field in _CRAWL_DELAY_DIRECTIVE,
-            field in _REQUEST_RATE_DIRECTIVE,
-            field in _HOST_DIRECTIVE,
-        ]
-    )
+    return field in _ALL_DIRECTIVES
+
+
+def _extract_directive(line: str) -> tuple[str, str] | None:
+    """Split a non-empty line into a lowercased directive field and a
+    stripped value, or return None if the line cannot be read as a
+    directive. A line with "<field>:<value>" shape is returned even when
+    the field is not a known directive, so that the caller can count it as
+    an invalid directive.
+
+    We are more generous than the specs: we allow e.g. "User-agent: foo",
+    "User-agent foo", "User agent: foo" and "User agent foo" even though all
+    specs only specify the first form. We also tolerate some misspellings.
+    """
+    field: str | None = None
+    value = ""
+    if ":" in line:
+        field, raw_value = line.split(":", 1)
+        field = field.strip().lower()
+        value = raw_value.strip()
+        if _is_valid_directive_field(field):
+            # Happy path
+            return field, value
+        if not raw_value or raw_value[0].isspace():
+            # The field is not a known directive, but the colon reads as a
+            # field separator (it ends the line or is followed by
+            # whitespace), so we keep the "<field>:<value>" interpretation
+            # and treat the line as an unknown directive.
+            return field, value
+
+    # There is no colon separator, or the field found is not a known
+    # directive and its colon does not read as a field separator. We will
+    # be generous here and give the line a second chance, parsing it as a
+    # whitespace-separated "<field> <value>" directive. This also salvages
+    # lines whose value contains a colon of its own, e.g.
+    # "Sitemap https://example.com/sitemap.xml".
+    words = line.split()
+    for word_count in range(1, _MAX_DIRECTIVE_WORDS + 1):
+        # Trying "<multiword> <field> <value>"
+        candidate = " ".join(words[:word_count]).lower()
+        if _is_valid_directive_field(candidate):
+            return candidate, " ".join(words[word_count:])
+
+    if field is None:
+        return None
+    # Salvage failed; keep the unknown "<field>:<value>" directive.
+    return field, value
 
 
 class Protego:
@@ -95,37 +147,35 @@ class Protego:
             if not line:
                 continue
 
-            # Format for a valid robots.txt rule is "<field>:<value>"
-            if line.find(":") != -1:
-                field, value = line.split(":", 1)
-            else:
-                # We will be generous here and give it a second chance.
-                parts = line.split(" ")
-                if len(parts) < 2:
-                    continue
+            parsed = _extract_directive(line)
+            if parsed is None:
+                continue
+            field, value = parsed
 
-                possible_filed = parts[0]
-                for i in range(1, len(parts)):
-                    if _is_valid_directive_field(possible_filed):
-                        field, value = possible_filed, " ".join(parts[i:])
-                        break
-                    possible_filed += " " + parts[i]
-                else:
-                    continue
+            # A user agent line, even one without a usable value, ends the
+            # previous record group.
+            if (
+                field in _USER_AGENT_DIRECTIVE
+                and previous_rule_field is not None
+                and previous_rule_field not in _USER_AGENT_DIRECTIVE
+            ):
+                current_rule_sets = []
 
-            field = field.strip().lower()
-            value = value.strip()
+            # Sitemap and Host are site-wide directives and don't matter for
+            # record grouping.
+            if field not in _SITE_WIDE_DIRECTIVES:
+                previous_rule_field = field
 
             # Ignore rules with no value part (e.g. "Disallow: ", "Allow: ").
             if not value:
-                previous_rule_field = field
                 continue
 
-            # Ignore rules without a corresponding user agent.
+            # Ignore rules without a corresponding user agent, except
+            # site-wide directives which need none.
             if (
                 not current_rule_sets
                 and field not in _USER_AGENT_DIRECTIVE
-                and field not in _SITEMAP_DIRECTIVE
+                and field not in _SITE_WIDE_DIRECTIVES
             ):
                 logger.debug(
                     f"Rule at line {self._total_line_seen} without any user agent to enforce it on."
@@ -135,12 +185,6 @@ class Protego:
             self._total_directive_seen += 1
 
             if field in _USER_AGENT_DIRECTIVE:
-                if (
-                    previous_rule_field
-                    and previous_rule_field not in _USER_AGENT_DIRECTIVE
-                ):
-                    current_rule_sets = []
-
                 # Wildcards are not supported in the user agent values.
                 # We will be generous here and remove all the wildcards.
                 user_agent = value.strip().lower()
@@ -191,8 +235,6 @@ class Protego:
 
             else:
                 self._invalid_directive_seen += 1
-
-            previous_rule_field = field
 
         for rule_set in self._user_agents.values():
             rule_set.finalize_rules()

--- a/tests/test_protego.py
+++ b/tests/test_protego.py
@@ -665,6 +665,108 @@ class TestProtego:
         assert rp.can_fetch("https://site.local/path1", "testbot")
         assert rp.can_fetch("https://site.local/path2", "testbot")
 
+    def test_empty_user_agent_line(self):
+        """A user agent line with no value still starts a new record group."""
+        content = """
+        User-Agent: alpha
+        Disallow: /x
+        User-Agent:
+        User-Agent: beta
+        Disallow: /y
+        """
+        rp = Protego.parse(content=content)
+        assert not rp.can_fetch("https://site.local/x", "alpha")
+        assert rp.can_fetch("https://site.local/y", "alpha")
+        assert rp.can_fetch("https://site.local/x", "beta")
+        assert not rp.can_fetch("https://site.local/y", "beta")
+
+        # Rules following a lone empty user agent line apply to no one.
+        content = """
+        User-Agent: alpha
+        Disallow: /x
+        User-Agent:
+        Disallow: /y
+        """
+        rp = Protego.parse(content=content)
+        assert not rp.can_fetch("https://site.local/x", "alpha")
+        assert rp.can_fetch("https://site.local/y", "alpha")
+
+        # An empty user agent line between two user agent lines does not
+        # split their group.
+        content = """
+        User-Agent: alpha
+        User-Agent:
+        User-Agent: beta
+        Disallow: /x
+        """
+        rp = Protego.parse(content=content)
+        assert not rp.can_fetch("https://site.local/x", "alpha")
+        assert not rp.can_fetch("https://site.local/x", "beta")
+
+        # A colon-less, value-less user agent line behaves the same as
+        # "User-Agent:".
+        content = """
+        User-Agent: alpha
+        Disallow: /x
+        user agent
+        Disallow: /y
+        """
+        rp = Protego.parse(content=content)
+        assert not rp.can_fetch("https://site.local/x", "alpha")
+        assert rp.can_fetch("https://site.local/y", "alpha")
+
+    def test_global_directives_do_not_split_groups(self):
+        """Sitemap and Host lines are site-wide; consecutive user agent lines
+        form a single group across them."""
+        content = """
+        User-Agent: one
+        Sitemap: https://site.local/sitemap.xml
+        User-Agent: two
+        Host: www.site.local
+        User-Agent: three
+        Disallow: /disallowed
+        """
+        rp = Protego.parse(content=content)
+        assert not rp.can_fetch("https://site.local/disallowed", "one")
+        assert not rp.can_fetch("https://site.local/disallowed", "two")
+        assert not rp.can_fetch("https://site.local/disallowed", "three")
+        assert list(rp.sitemaps) == ["https://site.local/sitemap.xml"]
+        assert rp.preferred_host == "www.site.local"
+
+        # They do not prevent a legitimate group split either.
+        content = """
+        User-Agent: one
+        Disallow: /disallowed
+        Sitemap: https://site.local/sitemap.xml
+        User-Agent: two
+        Crawl-delay: 5
+        """
+        rp = Protego.parse(content=content)
+        assert not rp.can_fetch("https://site.local/disallowed", "one")
+        assert rp.can_fetch("https://site.local/disallowed", "two")
+        assert rp.crawl_delay("one") is None
+        assert rp.crawl_delay("two") == 5.0
+
+    def test_preferred_host_before_user_agent(self):
+        """Host, like Sitemap, is a site-wide directive and needs no
+        preceding user agent line."""
+        content = """
+        Host: www.site.local
+        Sitemap: https://site.local/sitemap.xml
+        """
+        rp = Protego.parse(content=content)
+        assert rp.preferred_host == "www.site.local"
+        assert list(rp.sitemaps) == ["https://site.local/sitemap.xml"]
+
+        content = """
+        Host: www.site.local
+        User-Agent: *
+        Disallow: /disallowed
+        """
+        rp = Protego.parse(content=content)
+        assert rp.preferred_host == "www.site.local"
+        assert not rp.can_fetch("https://site.local/disallowed", "FooBot")
+
     def test_1994rfc_example(self):
         """Test parser on examples form 1994 RFC."""
         content = """
@@ -885,6 +987,103 @@ class TestProtego:
         rp = Protego.parse(content=wildcards_in_user_agent)
         assert not rp.can_fetch("http://foo.bar/myprofile", "foo*bot")
         assert not rp.can_fetch("http://foo.bar/myprofile", "foobot")
+
+    def test_generosity_case_insensitivity(self):
+        """Colon-less directive lines are salvaged regardless of case."""
+        content = """
+        User-Agent FooBot
+        Disallow /disallowed
+        Allow /disallowed/exception
+        Crawl-delay 5
+        """
+        rp = Protego.parse(content=content)
+        assert not rp.can_fetch("https://site.local/disallowed", "FooBot")
+        assert rp.can_fetch("https://site.local/disallowed/exception", "FooBot")
+        assert rp.can_fetch("https://site.local/disallowed", "BarBot")
+        assert rp.crawl_delay("FooBot") == 5.0
+
+    def test_generosity_visit_time(self):
+        """Colon-less Visit-time lines are salvaged like other directives."""
+        content = """
+        User-agent: *
+        visit-time 0200 0630
+        """
+        rp = Protego.parse(content=content)
+        visit_time = rp.visit_time("FooBot")
+        assert visit_time is not None
+        assert visit_time.start_time == time(2, 0)
+        assert visit_time.end_time == time(6, 30)
+
+    def test_generosity_sitemap(self):
+        """A colon-less Sitemap line still contains a colon in its URL value,
+        so it is parsed as "<field>:<value>" with a nonsense field before the
+        space-separated fallback can salvage it."""
+        content = """
+        User-agent: *
+        Disallow: /disallowed
+        Sitemap https://site.local/sitemap.xml
+        """
+        rp = Protego.parse(content=content)
+        assert list(rp.sitemaps) == ["https://site.local/sitemap.xml"]
+        assert not rp.can_fetch("https://site.local/disallowed", "FooBot")
+
+    def test_generosity_not_for_unknown_colon_directives(self):
+        """A line with an unknown "<field>: <value>" directive is ignored,
+        even if it starts with a directive name; only a colon that cannot be
+        a field separator (e.g. inside a URL) triggers the space-separated
+        fallback."""
+        content = """
+        User-agent: *
+        Disallow: /disallowed
+        User-agent must match exactly: see the docs
+        Allow: /disallowed/exception
+        """
+        rp = Protego.parse(content=content)
+        assert not rp.can_fetch("https://site.local/disallowed", "FooBot")
+        assert rp.can_fetch("https://site.local/disallowed/exception", "FooBot")
+
+        content = """
+        Host: www.site.local
+        Host name: www.other.example
+        Sitemap index: see https://site.local/sitemap.xml
+        """
+        rp = Protego.parse(content=content)
+        assert rp.preferred_host == "www.site.local"
+        assert list(rp.sitemaps) == []
+
+    def test_generosity_tab_separated(self):
+        """Colon-less directive lines may use any whitespace as the
+        field-value separator."""
+        content = "User-agent: *\nDisallow\t/disallowed"
+        rp = Protego.parse(content=content)
+        assert not rp.can_fetch("https://site.local/disallowed", "FooBot")
+
+    def test_empty_field_line_does_not_merge_groups(self):
+        """A line with an empty field (e.g. a stray ":") is ignored and does
+        not prevent the next user agent line from starting a new group."""
+        content = """
+        User-Agent: alpha
+        Disallow: /x
+        :
+        User-Agent: beta
+        Disallow: /y
+        """
+        rp = Protego.parse(content=content)
+        assert not rp.can_fetch("https://site.local/x", "alpha")
+        assert rp.can_fetch("https://site.local/y", "alpha")
+        assert not rp.can_fetch("https://site.local/y", "beta")
+
+        content = """
+        User-Agent: alpha
+        Disallow: /x
+        : foo
+        User-Agent: beta
+        Disallow: /y
+        """
+        rp = Protego.parse(content=content)
+        assert not rp.can_fetch("https://site.local/x", "alpha")
+        assert rp.can_fetch("https://site.local/y", "alpha")
+        assert not rp.can_fetch("https://site.local/y", "beta")
 
     def test_directive_case_insensitivity(self):
         content = """


### PR DESCRIPTION
1. Improve the generous parsing of malformed directives (case sensitivity, colons inside values, something else)
2. Visit-time was missing from `_is_valid_directive_field()`
3. Improve parsing of site-wide directives in a middle of groups and count `Host` as a site-wide one
4. Improve handling of empty `User-agent:` lines - they now count as group boundaries instead of doing something broken