### PR TITLE
Only accept plain decimal numbers in Crawl-delay and Request-rate.

### DIFF
--- a/src/protego/_ruleset.py
+++ b/src/protego/_ruleset.py
@@ -5,7 +5,14 @@ import math
 from typing import TYPE_CHECKING, NamedTuple
 
 from ._urlpattern import _URLPattern
-from ._utils import _hexescape, _parse_time_period, _quote_path, _quote_pattern
+from ._utils import (
+    _hexescape,
+    _parse_float,
+    _parse_int,
+    _parse_time_period,
+    _quote_path,
+    _quote_pattern,
+)
 
 if TYPE_CHECKING:
     from datetime import time
@@ -109,7 +116,7 @@ class _RuleSet:
     @crawl_delay.setter
     def crawl_delay(self, delay: str) -> None:
         try:
-            parsed_delay = float(delay)
+            parsed_delay = _parse_float(delay)
         except ValueError:
             parsed_delay = None
         if parsed_delay is None or not math.isfinite(parsed_delay) or parsed_delay < 0:
@@ -138,11 +145,11 @@ class _RuleSet:
             requests_str, seconds_str = rate.split("/")
             time_unit = seconds_str[-1].lower()
             if time_unit in ("s", "m", "h", "d"):
-                seconds = int(seconds_str[:-1])
+                seconds = _parse_int(seconds_str[:-1])
             else:
                 time_unit = "s"
-                seconds = int(seconds_str)
-            requests = int(requests_str)
+                seconds = _parse_int(seconds_str)
+            requests = _parse_int(requests_str)
 
             if requests <= 0 or seconds <= 0:
                 raise ValueError(f"Request rate must be positive: {value!r}")

--- a/src/protego/_utils.py
+++ b/src/protego/_utils.py
@@ -20,6 +20,23 @@ def _parse_time_period(time_period: str, separator: str = "-") -> tuple[time, ti
     return _parse_time_of_day(start_time_str), _parse_time_of_day(end_time_str)
 
 
+def _parse_int(value: str) -> int:
+    """Parse a plain decimal integer, rejecting other forms that int()
+    accepts, such as "1_0", "+5" or non-ASCII digits."""
+    if not (value.isascii() and value.isdigit()):
+        raise ValueError(f"Invalid integer: {value!r}")
+    return int(value)
+
+
+def _parse_float(value: str) -> float:
+    """Parse a plain non-negative decimal number, rejecting other forms that
+    float() accepts, such as "1_000", "1e2", "inf" or "-5"."""
+    integral = value.replace(".", "", 1)
+    if not (integral.isascii() and integral.isdigit()):
+        raise ValueError(f"Invalid number: {value!r}")
+    return float(value)
+
+
 def _unquote(url: str, ignore: str = "", errors: str = "replace") -> str:
     """Replace %xy escapes by their single-character equivalent."""
     if "%" not in url:

--- a/tests/test_protego.py
+++ b/tests/test_protego.py
@@ -194,7 +194,7 @@ class TestProtego:
         assert rp.crawl_delay("testbot") == value
 
     @pytest.mark.parametrize(
-        "value", ["random_word", "-5", "-0.5", "inf", "-inf", "nan"]
+        "value", ["random_word", "-5", "-0.5", "inf", "-inf", "nan", "1_000", "1e2"]
     )
     def test_malformed_crawl_delay(self, value: str) -> None:
         content = (
@@ -331,6 +331,8 @@ class TestProtego:
             "1/0",
             "0/0",
             "1/-5",
+            "1_0/5",
+            "1/1_0",
             # A malformed time window invalidates the whole rule.
             "1/5 9-17",
         ],


### PR DESCRIPTION
Follow-up to #78