### PR TITLE
Match URL paths containing an equal sign

### DIFF
--- a/src/protego/_utils.py
+++ b/src/protego/_utils.py
@@ -58,7 +58,7 @@ def _quote_path(path: str) -> str:
     """Return percent encoded path."""
     parts = urlparse(path)
     path = _unquote(parts.path, ignore="/%")
-    path = quote(path, safe="/%")
+    path = quote(path, safe="/%=")
 
     parts = ParseResult("", "", path, parts.params, parts.query, parts.fragment)
     path = urlunparse(parts)

--- a/tests/test_protego.py
+++ b/tests/test_protego.py
@@ -1358,6 +1358,20 @@ class TestProtego:
 
 
 @pytest.mark.parametrize(
+    ("url", "allowed"),
+    [
+        ("https://example.com/1/filter/page=5/", True),
+        ("https://example.com/1/filter/page%3D5/", True),
+        ("https://example.com/1/filter/page=5/x", False),
+    ],
+)
+def test_equal_sign_in_path(url, allowed):
+    content = "User-agent: *\nAllow: /*/filter/page=*/$\nDisallow: /\n"
+    rp = Protego.parse(content)
+    assert rp.can_fetch(url, "*") == allowed
+
+
+@pytest.mark.parametrize(
     ("allow", "disallow", "url", "allowed"),
     [
         ("*/p", "/", "http://example.com/page", True),


### PR DESCRIPTION
Fixes https://github.com/scrapy/protego/issues/51.