### PR TITLE
Follow RFC 9309: allow /robots.txt implicitly and reference the RFC in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,8 +10,15 @@ Protego
    :target: https://github.com/scrapy/protego/actions/workflows/tests-ubuntu.yml
    :alt: CI
 
-Protego is a pure-Python ``robots.txt`` parser with support for modern
-conventions.
+Protego is a pure-Python ``robots.txt`` parser. It implements the parsing and
+URL matching rules of `RFC 9309`_, and additionally supports the
+``Crawl-delay``, ``Request-rate``, ``Visit-time`` and ``Host`` extensions.
+
+Fetching ``robots.txt`` is up to you, and so are the parts of `RFC 9309`_ that
+govern it, such as the handling of HTTP status codes and redirects, caching, and
+imposing a parsing limit.
+
+.. _RFC 9309: https://www.rfc-editor.org/rfc/rfc9309.html
 
 
 Install
@@ -93,7 +100,8 @@ implemented in Python or featuring Python bindings:
 +============================+=========+=================+========+===========================+
 | Implementation language    | Python  | Python          | C++    | Python                    |
 +----------------------------+---------+-----------------+--------+---------------------------+
-| Reference specification    | Google_ | `Martijn Koster’s 1996 draft`_                       |
+| Reference specification    | `RFC    | `Martijn Koster’s 1996 draft`_                       |
+|                            | 9309`_  |                                                      |
 +----------------------------+---------+-----------------+--------+---------------------------+
 | `Wildcard support`_        | ✓       |                 | ✓      | ✓                         |
 +----------------------------+---------+-----------------+--------+---------------------------+
@@ -102,11 +110,10 @@ implemented in Python or featuring Python bindings:
 | Performance_               |         | +40%            | +1300% | -25%                      |
 +----------------------------+---------+-----------------+--------+---------------------------+
 
-.. _Google: https://developers.google.com/search/reference/robots_txt
-.. _Length-based precedence: https://developers.google.com/search/reference/robots_txt#order-of-precedence-for-group-member-lines
+.. _Length-based precedence: https://www.rfc-editor.org/rfc/rfc9309.html#section-2.2.2
 .. _Martijn Koster’s 1996 draft: https://www.robotstxt.org/norobots-rfc.txt
 .. _Performance: https://anubhavp28.github.io/gsoc-weekly-checkin-12/
-.. _Wildcard support: https://developers.google.com/search/reference/robots_txt#url-matching-based-on-path-values
+.. _Wildcard support: https://www.rfc-editor.org/rfc/rfc9309.html#section-2.2.3
 
 
 API Reference
@@ -131,6 +138,11 @@ Methods
 
 *   ``can_fetch(url, user_agent)`` Return True if the user agent can fetch the
     URL, otherwise return ``False``.
+
+    *user_agent* may be a product token, such as ``"mybot"``, or a whole
+    ``User-Agent`` header value, such as ``"Mozilla/5.0 (compatible;
+    mybot/1.0)"``; a group applies when its product token appears in
+    *user_agent* at a token boundary.
 
 *   ``crawl_delay(user_agent)`` Return the crawl delay specified for the user
     agent as a float. If nothing is specified, return ``None``.

--- a/src/protego/_protego.py
+++ b/src/protego/_protego.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from typing import TYPE_CHECKING
+from urllib.parse import urlparse
 
 from ._ruleset import RequestRate, VisitTime, _RuleSet
 
@@ -259,6 +260,8 @@ class Protego:
 
     def can_fetch(self, url: str, user_agent: str) -> bool:
         """Return True if the user agent can fetch the URL, otherwise return False."""
+        if urlparse(url).path == "/robots.txt":
+            return True
         matched_rule_set = self._get_matching_rule_set(user_agent)
         if not matched_rule_set:
             return True

--- a/tests/test_protego.py
+++ b/tests/test_protego.py
@@ -948,6 +948,16 @@ class TestProtego:
         assert not rp.can_fetch("/", "SomeOtherBot")
         assert not rp.can_fetch("/blahblahblah", "SomeOtherBot")
 
+    def test_robotstxt_is_always_allowed(self):
+        content = """
+        User-agent: *
+        Disallow: /
+        """
+        rp = Protego.parse(content=content)
+        assert rp.can_fetch("/robots.txt", "foobot")
+        assert rp.can_fetch("http://www.example.com/robots.txt", "foobot")
+        assert not rp.can_fetch("http://www.example.com/a/robots.txt", "foobot")
+
     def test_grouping_unknown_keys(self):
         """
         When we encounter unknown keys, we should disregard any grouping that may have


### PR DESCRIPTION
Resolves https://github.com/scrapy/protego/issues/35